### PR TITLE
Shrink og video and polish loop

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,14 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <meta property="og:title" content="We build, deploy, and scale your software applications the right way.">
     <meta property="og:description" content="STP | We build, deploy, and scale your software applications the right way. | Frontend and Design | Backend and Data | Infrastructure and Cloud">
-    <meta property="og:video" content="/seacoast-og.mp4">
-    <meta property="og:image" content="/seacoast-og.png">
+    <meta property="og:video" content="https://seacoast.partners/seacoast-og.mp4">
+    <meta property="og:video:type" content="video/mp4">
+    <meta property="og:video:width" content="1200">
+    <meta property="og:video:height" content="630">
+    <meta property="og:image" content="https://seacoast.partners/seacoast-og.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
     <meta property="og:url" content="https://seacoast.partners">
     <meta property="og:type" content="website">
     <link rel="icon" href="/favicon.ico" />


### PR DESCRIPTION
Shrunk the size of the video down quite a bit, thinking that was most likely the issue (not sure, but failed send and no send misfires and slow send made me think that). Also used a transition in iMovie to dissolve from the end of the loop into the start so you'll notice the jump is gone. Working on that for the hero video as well just going to handle that in some off-time tomorrow, since it is just a matter of choosing the smallest but highest quality export options. Can merge this one when you see it.

Also switched the URLs from absolute to full with protocol but I think that only would have affected Facebook. Same goes for the added sizing and type specs.