### PR TITLE
Add dissolve effect to hero video for smooth looping

### DIFF
--- a/src/pages/book-meeting/index.vue
+++ b/src/pages/book-meeting/index.vue
@@ -52,4 +52,10 @@ onUnmounted(() => {
 #form div {
     z-index: 0;
 }
+
+@media (max-width: 640px) {
+    #form {
+        height: 100svh;
+    }
+}
 </style>

--- a/src/pages/home/components/HeroSection.vue
+++ b/src/pages/home/components/HeroSection.vue
@@ -7,12 +7,8 @@
             loop
             poster="/seacoast.png"
         >
-            <!-- <source
-                src="/seacoast.mp4"
-                type="video/mp4"
-            > -->
             <source
-                src="/seacoast-dissolved.mp4"
+                src="/seacoast.mp4"
                 type="video/mp4"
             >
         </video>
@@ -193,6 +189,15 @@ header > * {
 }
 
 @media (max-width: 640px) {
+    section {
+        height: 100svh;
+    }
+
+    video {
+        height: 100svh;
+        width: 100svw;
+    }
+
     header > * {
         max-width: 100%;
         text-align: left;

--- a/src/pages/home/components/HeroSection.vue
+++ b/src/pages/home/components/HeroSection.vue
@@ -7,8 +7,12 @@
             loop
             poster="/seacoast.png"
         >
-            <source
+            <!-- <source
                 src="/seacoast.mp4"
+                type="video/mp4"
+            > -->
+            <source
+                src="/seacoast-dissolved.mp4"
                 type="video/mp4"
             >
         </video>
@@ -162,11 +166,11 @@ header > * {
 .button:first-child {
     border: 1px solid var(--primary-color);
     background-image: linear-gradient(90deg,
-            var(--quinary-color) 0%,
-            var(--quaternary-color) 20%,
-            var(--tertiary-color) 40%,
-            var(--secondary-color) 60%,
-            var(--primary-color) 100%);
+        var(--quinary-color) 0%,
+        var(--quaternary-color) 20%,
+        var(--tertiary-color) 40%,
+        var(--secondary-color) 60%,
+        var(--primary-color) 100%);
     background-position: right top;
     background-size: 100% auto;
     transition: background-size var(--transition-duration) ease-in-out;


### PR DESCRIPTION
Low priority change but toggle between the edited hero video and the original and see if it is an improvement. The only tradeoff is the video quality might be slightly less than the original (may not be, I just had to export from iMovie with the "low" quality selection) and it is about 8 seconds shorter overall resulting in the same <30MB file size.